### PR TITLE
fix: track gc pause time in seconds

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "@chainsafe"
+  "extends": "@chainsafe",
+  "parserOptions": {
+    "project": "./tsconfig.lint.json"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ export function gcStats(
     const { gcType, cost, beforeGC, afterGC } = stats;
 
     gcCount.labels(gcType).inc();
-    gcTimeCount.labels(gcType).inc(cost);
+    gcTimeCount.labels(gcType).inc(cost / 1e6);
 
     const diffUsedHeapSize =
       afterGC.heapStatistics.usedHeapSize -

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "test"],
+}


### PR DESCRIPTION
https://github.com/nodejs/node/blob/bcd35c334ec75402ee081f1c4da128c339f70c24/src/node_v8.cc#L326
`cost` is returned in microseconds (converted from nanoseconds)

The metrics documentation suggest data should be in seconds.